### PR TITLE
Adding field hints

### DIFF
--- a/langdspy/__init__.py
+++ b/langdspy/__init__.py
@@ -1,4 +1,4 @@
-from field_descriptors import InputField, OutputField, InputFieldList
+from field_descriptors import InputField, OutputField, InputFieldList, HintField
 from prompt_strategies import PromptSignature, PromptStrategy, DefaultPromptStrategy
 
 from .model import Model, PromptRunner, MultiPromptRunner

--- a/langdspy/field_descriptors.py
+++ b/langdspy/field_descriptors.py
@@ -36,6 +36,21 @@ class FieldDescriptor:
         else:
             return True
 
+class HintField(FieldDescriptor):
+    HINT_TOKEN = "💡"
+
+    def __init__(self, desc: str, formatter: Optional[Callable[[Any], Any]] = None, transformer: Optional[Callable[[Any], Any]] = None, validator: Optional[Callable[[Any], Any]] = None, **kwargs):
+        # Provide a default value for the name parameter, such as an empty string
+        super().__init__("", desc, formatter, transformer, validator, **kwargs)
+
+    def format_prompt_description(self):
+        return f"{self.HINT_TOKEN} {self.desc}"
+
+
+    def format_prompt_description(self):
+        return f"{self.HINT_TOKEN} {self.desc}"
+
+
 class InputField(FieldDescriptor):
     START_TOKEN = "✅"
 

--- a/langdspy/formatters.py
+++ b/langdspy/formatters.py
@@ -16,6 +16,9 @@ def as_docs(docs: List[Document], kwargs: Dict) -> str:
 
     return formatted_docs
 
+def as_int(input, kwargs: Dict) -> str:
+    return f"{input}"
+
 def as_multiline(input, kwargs: Dict) -> str:
     return f"«{input}»"
 

--- a/langdspy/prompt_strategies.py
+++ b/langdspy/prompt_strategies.py
@@ -18,29 +18,33 @@ from langchain_core.runnables.config import (
 )
 import logging
 
-from field_descriptors import InputField, OutputField
+from field_descriptors import InputField, OutputField, HintField
 
 logger = logging.getLogger(__name__)
 
 class PromptSignature(BasePromptTemplate, BaseModel):
-    # Assuming input_variables and output_variables are defined as class attributes
     input_variables: Dict[str, Any] = []
     output_variables: Dict[str, Any] = []
+    hint_variables: Dict[str, Any] = []  # New attribute for hint fields
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
         inputs = {}
         outputs = {}
+        hints = {}  # New dictionary to hold hint fields
 
         for name, attribute in self.__class__.__fields__.items():
             if issubclass(attribute.type_, InputField):
                 inputs[name] = attribute.default
             elif issubclass(attribute.type_, OutputField):
                 outputs[name] = attribute.default
+            elif issubclass(attribute.type_, HintField):  # Check if the field is a HintField
+                hints[name] = attribute.default 
 
         self.input_variables = inputs
         self.output_variables = outputs
+        self.hint_variables = hints 
 
 class PromptStrategy(BaseModel):
     def validate_inputs(self, inputs_dict):
@@ -66,12 +70,25 @@ class DefaultPromptStrategy(PromptStrategy):
         # logger.debug(f"Formatting prompt with kwargs: {kwargs}")
         self.validate_inputs(kwargs)
 
-        prompt = "Follow the following format. Attributes that have values should not be changed or repeated."
+        prompt = "Follow the following format. Attributes that have values should not be changed or repeated. "
 
         if len(self.output_variables) > 1:
-            prompt += "Fill any missing attributes and their values."
+            #Provide answers for Solution Effectiveness, Rationale and Confidence
+            # Extract names from output_variables
+            output_field_names = ', '.join([output_field.name for output_field in self.output_variables.values()])
+
+            # Format the instruction with the extracted names
+            prompt += f"Provide answers for {output_field_names}\n"
+
+
+        if self.hint_variables:
+            prompt += "\n"
+
+            for _, hint_field in self.hint_variables.items():
+                prompt += hint_field.format_prompt_description() + "\n"
 
         prompt += "\n\n"
+
         for input_name, input_field in self.input_variables.items():
             # prompt += f"⏎{input_field.name}: {input_field.desc}\n"
             prompt += input_field.format_prompt_description() + "\n"

--- a/langdspy/prompt_strategies.py
+++ b/langdspy/prompt_strategies.py
@@ -61,8 +61,6 @@ class PromptStrategy(BaseModel):
                 return output_name
 
 
-
-
 class DefaultPromptStrategy(PromptStrategy):
     OUTPUT_TOKEN = "🔑"
 

--- a/langdspy/validators.py
+++ b/langdspy/validators.py
@@ -24,6 +24,15 @@ def is_one_of(input, output_val, kwargs) -> bool:
     if not kwargs.get('choices'):
         raise ValueError("is_one_of validator requires 'choices' keyword argument")
 
+
+    none_ok = False
+    if kwargs.get('none_ok', False):
+        none_ok = True
+
+    if none_ok and output_val.lower().startswith("none"):
+        logger.debug(f"None is okay and got none")
+        return True
+
     try:
         if not kwargs.get('case_sensitive', False):
             choices = [c.lower() for c in kwargs['choices']]
@@ -37,5 +46,7 @@ def is_one_of(input, output_val, kwargs) -> bool:
 
         return False
     except Exception as e:
-        logger.error(f"Field must be one of {choices}, not {output_val}")
+        logger.error(f"Field must be one of {kwargs.get('choices')}, not {output_val}")
+        import traceback
+        traceback.print_exc()
         return False


### PR DESCRIPTION
Adds hints which makes much more performant prompts when used well:

💡 Ignore buyer's requests to get in contact with sellers. They would prefer we solve the problem for them without waiting for the seller to respond.
💡 Do not infer buyer requests. It is better to say a solution doesn't apply than it is to apply the wrong solution.


✅This Order Summary: The order we're considering applying this business rule to
✅Summary of Buyer Concerns: Summary of the issue this buyer is facing, including their desired outcome, any requested remediation, and major complaint.
✅Solution Evaluation Criteria: Criteria to be used when evaluating this potential action to determine if it is suitable. One of these criteria must be explicitly true for the Solution to be acceptable.
✅Proposed Action: The proposed action to be taken to resolve the buyer's issue.
🔑Solution Effectiveness: Based on the hints above, classify the proposed action as 'Fully Resolves', 'Partially Resolves', or 'Does Not Resolve' the buyer's issue.
🔑Rationale: Rationale for why the solution effectiveness was chosen, cite the specific resolution requirements that is true including any numbers (such as days waiting).
🔑Confidence: Classify the confidence in the proposed action as 'High', 'Medium', or 'Low'

---

✅This Order Summary:
- order_id: 5372737222
- cnt_shipped: 3
- cnt_successful_transactions: 6
- sub_status: Active
- days_waiting_past_ship_date: 80
✅Summary of Buyer Concerns: Buyer is unable to find the cancel option for order #14361788713 and encounters a 'fail to load' error when trying to use the Contact Seller button. The buyer wants to cancel any renewal for this order and is seeking assistance in doing so.
✅Solution Evaluation Criteria [0]: Is the buyer explicitly asking to cancel?
✅Proposed Action: Cancel the subscription
🔑Solution Effectiveness:
🔑Rationale:
🔑Confidence: