### PR TITLE
Prompt caching anthropic

### DIFF
--- a/langdspy/prompt_runners.py
+++ b/langdspy/prompt_runners.py
@@ -255,10 +255,10 @@ class PromptRunner(RunnableSerializable):
             if config is None:
                 config = {}
 
-            if 'llm' not in config:
+            llm = config.get('llm')
+            if llm is None:
                 raise ValueError("'llm' is not present in the config")
 
-            llm = config['llm']
             max_retries = config.get('max_tries', 3)
 
             if '__examples__' in config:
@@ -270,7 +270,7 @@ class PromptRunner(RunnableSerializable):
             formatted_prompt = self.template.format_prompt(**kwargs, llm_type=llm_type)
             
             res = self._invoke_with_retries(
-                lambda: llm.invoke(formatted_prompt).content,
+                lambda: llm.invoke(formatted_prompt, config=config).content,
                 input,
                 max_retries,
                 config=config

--- a/langdspy/prompt_runners.py
+++ b/langdspy/prompt_runners.py
@@ -159,6 +159,8 @@ class PromptRunner(RunnableSerializable):
         try:
             if llm_type == 'anthropic':
                 prompt_res = chain.invoke(formatted_prompt, config=config)
+            elif llm_type == 'openai_json':
+                prompt_res = chain.invoke(formatted_prompt, config=config)
             else:
                 prompt_res = chain.invoke(invoke_args, config=config)
             return formatted_prompt, prompt_res

--- a/langdspy/prompt_runners.py
+++ b/langdspy/prompt_runners.py
@@ -269,8 +269,10 @@ class PromptRunner(RunnableSerializable):
             
             formatted_prompt = self.template.format_prompt(**kwargs, llm_type=llm_type)
             
+            chain = formatted_prompt | llm | StrOutputParser()
+            
             res = self._invoke_with_retries(
-                lambda: llm.invoke(formatted_prompt, config=config).content,
+                lambda: chain.invoke(input, config=config),
                 input,
                 max_retries,
                 config=config

--- a/langdspy/prompt_runners.py
+++ b/langdspy/prompt_runners.py
@@ -274,13 +274,16 @@ class PromptRunner(RunnableSerializable):
             
             if isinstance(formatted_prompt, list):
                 # If formatted_prompt is a list, assume it's a list of messages
-                chain = lambda x: llm.invoke(formatted_prompt) | StrOutputParser()
+                chain = lambda x: llm.invoke(formatted_prompt)
                 res = self._invoke_with_retries(
                     lambda: chain(input),
                     input,
                     max_retries,
                     config=config
                 )
+                # Extract content if it's an AIMessage
+                if hasattr(res, 'content'):
+                    res = res.content
             else:
                 chain = formatted_prompt | llm | StrOutputParser()
                 res = self._invoke_with_retries(

--- a/langdspy/prompt_runners.py
+++ b/langdspy/prompt_runners.py
@@ -164,6 +164,10 @@ class PromptRunner(RunnableSerializable):
             return formatted_prompt, prompt_res
         except Exception as e:
             logger.error(f"Error executing prompt: {str(e)}")
+            logger.error(f"Chain: {chain}")
+            logger.error(f"Input: {input}")
+            logger.error(f"Config: {config}")
+            logger.error(f"LLM Type: {llm_type}")
             raise
 
     def _get_trained_state(self, config):

--- a/langdspy/prompt_runners.py
+++ b/langdspy/prompt_runners.py
@@ -272,7 +272,11 @@ class PromptRunner(RunnableSerializable):
             
             formatted_prompt = self.template.format_prompt(**kwargs, llm_type=llm_type)
             
-            chain = formatted_prompt | llm | StrOutputParser()
+            if isinstance(formatted_prompt, list):
+                # If formatted_prompt is a list, assume it's a list of messages
+                chain = lambda x: llm.invoke(formatted_prompt) | StrOutputParser()
+            else:
+                chain = formatted_prompt | llm | StrOutputParser()
             
             res = self._invoke_with_retries(
                 lambda: chain.invoke(input, config=config),

--- a/langdspy/prompt_runners.py
+++ b/langdspy/prompt_runners.py
@@ -153,7 +153,7 @@ class PromptRunner(RunnableSerializable):
         logger.debug(f"CONFIG: {config}")
         
         if llm_type == 'anthropic':
-            prompt_res = chain.invoke({"messages": formatted_prompt}, config=config)
+            prompt_res = chain.invoke(formatted_prompt, config=config)
         else:
             prompt_res = chain.invoke(invoke_args, config=config)
         return formatted_prompt, prompt_res

--- a/langdspy/prompt_runners.py
+++ b/langdspy/prompt_runners.py
@@ -275,15 +275,20 @@ class PromptRunner(RunnableSerializable):
             if isinstance(formatted_prompt, list):
                 # If formatted_prompt is a list, assume it's a list of messages
                 chain = lambda x: llm.invoke(formatted_prompt) | StrOutputParser()
+                res = self._invoke_with_retries(
+                    lambda: chain(input),
+                    input,
+                    max_retries,
+                    config=config
+                )
             else:
                 chain = formatted_prompt | llm | StrOutputParser()
-            
-            res = self._invoke_with_retries(
-                lambda: chain.invoke(input, config=config),
-                input,
-                max_retries,
-                config=config
-            )
+                res = self._invoke_with_retries(
+                    lambda: chain.invoke(input, config=config),
+                    input,
+                    max_retries,
+                    config=config
+                )
             
             logger.debug(f"Result from _invoke_with_retries: {res}")
 

--- a/langdspy/prompt_runners.py
+++ b/langdspy/prompt_runners.py
@@ -252,6 +252,9 @@ class PromptRunner(RunnableSerializable):
             logger.debug(f"PromptRunner invoke called with input: {input}")
             logger.debug(f"Config: {config}")
 
+            if 'llm' not in config:
+                raise ValueError("'llm' is not present in the config")
+
             chain = (
                 self.template
                 | config['llm']
@@ -275,6 +278,8 @@ class PromptRunner(RunnableSerializable):
             return prediction
         except Exception as e:
             logger.error(f"Error in PromptRunner invoke: {str(e)}")
+            logger.error(f"Input: {input}")
+            logger.error(f"Config: {config}")
             import traceback
             logger.error(traceback.format_exc())
             raise

--- a/langdspy/prompt_runners.py
+++ b/langdspy/prompt_runners.py
@@ -158,7 +158,10 @@ class PromptRunner(RunnableSerializable):
         
         try:
             if llm_type in ['anthropic', 'openai_json']:
-                prompt_res = chain.invoke(formatted_prompt)
+                if isinstance(formatted_prompt, list):
+                    prompt_res = chain.invoke({"messages": formatted_prompt})
+                else:
+                    prompt_res = chain.invoke(formatted_prompt)
             else:
                 prompt_res = chain.invoke(invoke_args)
             return formatted_prompt, prompt_res

--- a/langdspy/prompt_runners.py
+++ b/langdspy/prompt_runners.py
@@ -129,6 +129,7 @@ class PromptRunner(RunnableSerializable):
                     return parsed_output
 
             except Exception as e:
+                logger.error(f"Error in _invoke_with_retries: {str(e)}")
                 self._handle_exception(e, max_tries)
 
             max_tries -= 1
@@ -152,11 +153,15 @@ class PromptRunner(RunnableSerializable):
         self._log_prompt(formatted_prompt)
         logger.debug(f"CONFIG: {config}")
         
-        if llm_type == 'anthropic':
-            prompt_res = chain.invoke(formatted_prompt, config=config)
-        else:
-            prompt_res = chain.invoke(invoke_args, config=config)
-        return formatted_prompt, prompt_res
+        try:
+            if llm_type == 'anthropic':
+                prompt_res = chain.invoke(formatted_prompt, config=config)
+            else:
+                prompt_res = chain.invoke(invoke_args, config=config)
+            return formatted_prompt, prompt_res
+        except Exception as e:
+            logger.error(f"Error executing prompt: {str(e)}")
+            raise
 
     def _get_trained_state(self, config):
         trained_state = config.get('trained_state') or self.model_kwargs.get('trained_state') or self.kwargs.get('trained_state')

--- a/langdspy/prompt_runners.py
+++ b/langdspy/prompt_runners.py
@@ -152,7 +152,10 @@ class PromptRunner(RunnableSerializable):
         self._log_prompt(formatted_prompt)
         logger.debug(f"CONFIG: {config}")
         
-        prompt_res = chain.invoke(invoke_args, config=config)
+        if llm_type == 'anthropic':
+            prompt_res = chain.invoke({"messages": formatted_prompt}, config=config)
+        else:
+            prompt_res = chain.invoke(invoke_args, config=config)
         return formatted_prompt, prompt_res
 
     def _get_trained_state(self, config):

--- a/langdspy/prompt_runners.py
+++ b/langdspy/prompt_runners.py
@@ -247,10 +247,13 @@ class PromptRunner(RunnableSerializable):
             else:
                 return {attr_name: None for attr_name in self.template.output_variables.keys()}
  
-    def invoke(self, input: Input, config: Optional[RunnableConfig] = {}) -> Output:
+    def invoke(self, input: Input, config: Optional[RunnableConfig] = None) -> Output:
         try:
             logger.debug(f"PromptRunner invoke called with input: {input}")
             logger.debug(f"Config: {config}")
+
+            if config is None:
+                config = {}
 
             if 'llm' not in config:
                 raise ValueError("'llm' is not present in the config")

--- a/langdspy/prompt_runners.py
+++ b/langdspy/prompt_runners.py
@@ -157,9 +157,7 @@ class PromptRunner(RunnableSerializable):
         logger.debug(f"CONFIG: {config}")
         
         try:
-            if llm_type == 'anthropic':
-                prompt_res = chain.invoke(formatted_prompt, config=config)
-            elif llm_type == 'openai_json':
+            if llm_type in ['anthropic', 'openai_json']:
                 prompt_res = chain.invoke(formatted_prompt, config=config)
             else:
                 prompt_res = chain.invoke(invoke_args, config=config)

--- a/langdspy/prompt_runners.py
+++ b/langdspy/prompt_runners.py
@@ -274,17 +274,17 @@ class PromptRunner(RunnableSerializable):
             
             if isinstance(formatted_prompt, list):
                 # If formatted_prompt is a list, assume it's a list of messages
-                chain = lambda: llm.invoke({"messages": formatted_prompt}) | StrOutputParser()
+                chain = lambda x: llm.invoke(formatted_prompt) | StrOutputParser()
                 res = self._invoke_with_retries(
-                    chain,
+                    lambda: chain(input),
                     input,
                     max_retries,
                     config=config
                 )
             else:
-                chain = lambda: llm.invoke(formatted_prompt) | StrOutputParser()
+                chain = formatted_prompt | llm | StrOutputParser()
                 res = self._invoke_with_retries(
-                    chain,
+                    lambda: chain.invoke(input, config=config),
                     input,
                     max_retries,
                     config=config

--- a/langdspy/prompt_runners.py
+++ b/langdspy/prompt_runners.py
@@ -274,17 +274,17 @@ class PromptRunner(RunnableSerializable):
             
             if isinstance(formatted_prompt, list):
                 # If formatted_prompt is a list, assume it's a list of messages
-                chain = lambda x: llm.invoke(formatted_prompt) | StrOutputParser()
+                chain = lambda: llm.invoke({"messages": formatted_prompt}) | StrOutputParser()
                 res = self._invoke_with_retries(
-                    lambda: chain(input),
+                    chain,
                     input,
                     max_retries,
                     config=config
                 )
             else:
-                chain = formatted_prompt | llm | StrOutputParser()
+                chain = lambda: llm.invoke(formatted_prompt) | StrOutputParser()
                 res = self._invoke_with_retries(
-                    lambda: chain.invoke(input, config=config),
+                    chain,
                     input,
                     max_retries,
                     config=config

--- a/langdspy/prompt_runners.py
+++ b/langdspy/prompt_runners.py
@@ -158,9 +158,9 @@ class PromptRunner(RunnableSerializable):
         
         try:
             if llm_type in ['anthropic', 'openai_json']:
-                prompt_res = chain.invoke(formatted_prompt, config=config)
+                prompt_res = chain.invoke(formatted_prompt)
             else:
-                prompt_res = chain.invoke(invoke_args, config=config)
+                prompt_res = chain.invoke(invoke_args)
             return formatted_prompt, prompt_res
         except Exception as e:
             logger.error(f"Error executing prompt: {str(e)}")

--- a/langdspy/prompt_strategies.py
+++ b/langdspy/prompt_strategies.py
@@ -483,3 +483,29 @@ class DefaultPromptStrategy(PromptStrategy):
         except Exception as e:
             logger.error(f"An error occurred while parsing JSON output: {e}")
             raise e
+from typing import Dict, Any, Optional
+
+class PromptGenerateState(PromptSignature):
+    state = InputField(name="State", desc="This is the state")
+    
+    capital = OutputField(name="State Capital", desc="The capital city of this state")
+
+    __examples__ = [
+        ({'state': 'California'}, {'capital': "Sacramento"}),
+        ({'state': 'Argentina'}, {'capital': "Buenos Aires"}),
+    ]
+
+
+class GenerateState(BaseModel):
+    generate_output = PromptRunner(template_class=PromptGenerateState, prompt_strategy=DefaultPromptStrategy)
+
+    def invoke(self, input: Dict[str, Any], config: Optional[Dict[str, Any]] = None) -> str:
+        try:
+            desc = self.generate_output.invoke(input, config)
+            if hasattr(desc, 'capital'):
+                return desc.capital
+            else:
+                raise ValueError("The 'capital' field is missing from the output")
+        except Exception as e:
+            logger.error(f"Error in GenerateState.invoke: {str(e)}")
+            return f"Error: Unable to generate state capital. {str(e)}"

--- a/langdspy/prompt_strategies.py
+++ b/langdspy/prompt_strategies.py
@@ -483,29 +483,3 @@ class DefaultPromptStrategy(PromptStrategy):
         except Exception as e:
             logger.error(f"An error occurred while parsing JSON output: {e}")
             raise e
-from typing import Dict, Any, Optional
-
-class PromptGenerateState(PromptSignature):
-    state = InputField(name="State", desc="This is the state")
-    
-    capital = OutputField(name="State Capital", desc="The capital city of this state")
-
-    __examples__ = [
-        ({'state': 'California'}, {'capital': "Sacramento"}),
-        ({'state': 'Argentina'}, {'capital': "Buenos Aires"}),
-    ]
-
-
-class GenerateState(BaseModel):
-    generate_output = PromptRunner(template_class=PromptGenerateState, prompt_strategy=DefaultPromptStrategy)
-
-    def invoke(self, input: Dict[str, Any], config: Optional[Dict[str, Any]] = None) -> str:
-        try:
-            desc = self.generate_output.invoke(input, config)
-            if hasattr(desc, 'capital'):
-                return desc.capital
-            else:
-                raise ValueError("The 'capital' field is missing from the output")
-        except Exception as e:
-            logger.error(f"Error in GenerateState.invoke: {str(e)}")
-            return f"Error: Unable to generate state capital. {str(e)}"

--- a/langdspy/prompt_strategies.py
+++ b/langdspy/prompt_strategies.py
@@ -58,6 +58,9 @@ class PromptSignature(BasePromptTemplate, BaseModel):
         self.validate_examples()
 
     def _validate_input(self, input_dict: Dict[str, Any]) -> Dict[str, Any]:
+        if not self.input_variables:
+            return input_dict  # Return the input as-is if there are no input variables defined
+
         validated_input = {}
         for name, field in self.input_variables.items():
             if name not in input_dict:

--- a/langdspy/prompt_strategies.py
+++ b/langdspy/prompt_strategies.py
@@ -61,7 +61,11 @@ class PromptSignature(BasePromptTemplate, BaseModel):
         validated_input = {}
         for name, field in self.input_variables.items():
             if name not in input_dict:
-                raise ValueError(f"Missing input: {name}")
+                if not field.kwargs.get('optional', False):
+                    raise ValueError(f"Missing required input: {name}")
+                else:
+                    validated_input[name] = None
+                    continue
             value = input_dict[name]
             if not field.validate_value({}, value):
                 raise ValueError(f"Invalid input for {name}: {value}")

--- a/langdspy/prompt_strategies.py
+++ b/langdspy/prompt_strategies.py
@@ -130,8 +130,8 @@ class PromptStrategy(BaseModel):
 
         try:
             # Extract content if output is an AIMessage
-            if hasattr(output, 'content'):
-                output = output.content
+            #if hasattr(output, 'content'):
+            #    output = output.content
             validated_kwargs = self._validate_input(kwargs)
 
             if llm_type == 'openai':
@@ -436,14 +436,26 @@ class DefaultPromptStrategy(PromptStrategy):
             if hasattr(output, 'content'):
                 output = output.content
 
+            print(self)
+            print(f"output: {output}")    
+                    
             parsed_fields = {}
             for output_name, output_field in self.output_variables.items():
                 pattern = fr"<{output_field.name}>(.*?)</{output_field.name}>"
-                matches = re.findall(pattern, output, re.DOTALL)
-                if matches:
-                    # Take the last match
-                    last_match = matches[-1]
-                    parsed_fields[output_name] = last_match.strip()
+                if isinstance(output, str):
+                    matches = re.findall(pattern, output, re.DOTALL)
+                    if matches:
+                        # Take the last match
+                        last_match = matches[-1]
+                        parsed_fields[output_name] = last_match.strip()
+                
+                elif isinstance(output, dict):
+                    if output_field.name in output.keys():
+                        parsed_fields[output_name] = output[output_name]
+                else:
+                    raise ValueError(f"Invalid output type: {type(output)}")
+                    
+                
 
             logger.debug(f"Parsed fields: {parsed_fields}")
             return parsed_fields

--- a/langdspy/prompt_strategies.py
+++ b/langdspy/prompt_strategies.py
@@ -451,11 +451,14 @@ class DefaultPromptStrategy(PromptStrategy):
                 
                 elif isinstance(output, dict):
                     if output_field.name in output.keys():
-                        parsed_fields[output_name] = output[output_name]
+                        parsed_fields[output_name] = output[output_field.name]
                 else:
                     raise ValueError(f"Invalid output type: {type(output)}")
                     
-                
+            # Ensure all output fields are present in parsed_fields
+            for output_name in self.output_variables.keys():
+                if output_name not in parsed_fields:
+                    parsed_fields[output_name] = None
 
             logger.debug(f"Parsed fields: {parsed_fields}")
             return parsed_fields


### PR DESCRIPTION
Including input fields descriptions as long as examples into the prompt caching when using an Anthropic model. This allows to reduce costs avoiding repeated instructions and it can improve results when using more previous information to help the algorithm to decide a problem.

IMPORTANT: as for the prompt caching to properly work, the ChatAnthropic object passed on config['llm'] must be created with the following header passed on clientOptions parameter in the constructor method:

ANTHROPIC_PROMPT_CACHE_HEADERS = {
            "defaultHeaders": {
                "anthropic-beta": "prompt-caching-2024-07-31",
            }
        }
        
 ChatAnthropic(..., clientOptions=ANTHROPIC_PROMPT_CACHE_HEADERS,  ...)